### PR TITLE
Chore: restart armada-agent service when updating the charm

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -112,6 +112,7 @@ class ArmadaAgentCharm(CharmBase):
         try:
             self.armada_agent_ops.upgrade(version)
             event.set_results({"upgrade": "success"})
+            self.armada_agent_ops.restart_agent()
         except:
             self.unit.status = BlockedStatus("Error upgrading armada-agent")
             event.fail(message="Error upgrading armada-agent")


### PR DESCRIPTION
Currently updating the charm doesn't restart the `armada-agent` systemd service, so, updating the `armada-agent` package version will make no effect in the service at all. This PR fixes this behaviour.