### PR TITLE
remove --use-deprecated flag from the cluster agent installation

### DIFF
--- a/src/cluster_agent_ops.py
+++ b/src/cluster_agent_ops.py
@@ -151,8 +151,6 @@ class ClusterAgentOps:
         cmd = [
             self._PIP_CMD,
             "install",
-            "--use-deprecated",
-            "html5lib",
             "-U",
             self._PACKAGE_NAME,
         ]


### PR DESCRIPTION
this PR removes the `--use-deprecated`flag from the cluster agent package installation