### PR TITLE
Clear cache in charms after install or upgrade

### DIFF
--- a/src/cluster_agent_ops.py
+++ b/src/cluster_agent_ops.py
@@ -64,6 +64,9 @@ class ClusterAgentOps:
                 mapped_key = key.replace("-", "_").upper()
                 print(f"{prefix}{mapped_key}={value}", file=env_file)
 
+        # Clear cached data
+        self._clear_cache_dir()
+
     def systemctl(self, operation: str):
         """
         Run systemctl operation for the service.

--- a/src/cluster_agent_ops.py
+++ b/src/cluster_agent_ops.py
@@ -39,11 +39,15 @@ class ClusterAgentOps:
         self._install_extra_deps()
         # Install cluster-agent
         self._install_cluster_agent()
+        # Clear cached data
+        self._clear_cache_dir()
         # Provision the cluster-agent systemd service.
         self._setup_systemd()
 
     def upgrade(self, version: str):
         """Upgrade the cluster-agent python package."""
+        # Clear cached data
+        self._clear_cache_dir()
         self._upgrade_cluster_agent(version)
 
     def configure_env_defaults(self, config_context: Dict[str, Any]):
@@ -55,9 +59,9 @@ class ClusterAgentOps:
         configured dot-env file. If the file exists, it should be replaced.
         """
         prefix = "CLUSTER_AGENT_"
-        with open(self._ENV_DEFAULTS, 'w') as env_file:
+        with open(self._ENV_DEFAULTS, "w") as env_file:
             for (key, value) in config_context.items():
-                mapped_key = key.replace('-', '_').upper()
+                mapped_key = key.replace("-", "_").upper()
                 print(f"{prefix}{mapped_key}={value}", file=env_file)
 
     def systemctl(self, operation: str):
@@ -176,6 +180,19 @@ class ClusterAgentOps:
         except subprocess.CalledProcessError as e:
             logger.error(f"Error running {' '.join(cmd)} - {e}")
             raise e
+
+    def _clear_cache_dir(self):
+        """Clear the cache dir. Cluster-agent will recreate it on the next run."""
+
+        CACHE_DIR = Path.home() / ".cache/cluster-agent"
+
+        if CACHE_DIR.exists():
+            logger.debug(f"Clearing cache dir {CACHE_DIR.as_posix()}")
+            rmtree(CACHE_DIR, ignore_errors=True)
+        else:
+            logger.debug(
+                f"Tried to clean cache dir {CACHE_DIR.as_posix()}, but it does not exist"
+            )
 
     def start_agent(self):
         """Starts the cluster-agent"""


### PR DESCRIPTION
The token caches for the Vantage services (agents and CLIs) need to be cleared out after the charm has been installed or upgraded. Add logic to clear the cache to the charm code.

https://app.clickup.com/t/18022949/ARMADA-854