### PR TITLE
ASP-3502 Set slurm restd version dynamically on cluster-agent

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to charm-cluster-agent.
 
 Unreleased
 ----------
+- Added the new setting slurm-restd-version.
 
 1.0.0 - 2022-12-15
 ------------------

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,4 @@
 options:
-
   # Used by systemd to specify the frequency of the agent execution
   stat-interval:
     type: int
@@ -18,7 +17,12 @@ options:
     default: http://127.0.0.1:6820
     description: |
       The url for the Slurm REST API.
-  
+  slurm-restd-version:
+    type: string
+    default: v0.0.36
+    description: |
+      The target version for the Slurm REST API.
+
   # Slurmrestd authentication
   slurmrestd-jwt-key-path:
     type: string

--- a/src/charm.py
+++ b/src/charm.py
@@ -106,6 +106,7 @@ class ClusterAgentCharm(CharmBase):
         settings_to_map = {
             "base-api-url": True,
             "base-slurmrestd-url": True,
+            "slurm-restd-version": False,
             "slurmrestd-jwt-key-path": False,
             "slurmrestd-jwt-key-string": False,
             "slurmrestd-use-key-path": True,
@@ -141,7 +142,7 @@ class ClusterAgentCharm(CharmBase):
 
         env_context = dict()
 
-        for (setting, is_required) in settings_to_map.items():
+        for setting, is_required in settings_to_map.items():
             value = self.model.config.get(setting, unset)
 
             # If any config value is not yet available, defer


### PR DESCRIPTION
#### What
Set slurm restd version dynamically on cluster-agent.

#### Why
As a Jobbergate maintainer, I need more control over the slurm restd version used on requests, so that it can be set dynamically from the infra bundles and work with different slurm versions.

`Task`: https://jira.scania.com/browse/ASP-3502

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).